### PR TITLE
Soft cron now replicates hard cron when DISABLE_WP_CRON is true

### DIFF
--- a/bitcoinway-woocommerce.php
+++ b/bitcoinway-woocommerce.php
@@ -5,7 +5,7 @@
 Plugin Name: Bitcoin Cash Payments for WooCommerce
 Plugin URI: https://github.com/sanchaz/bitcoin-cash-payments-for-woocommerce
 Description: Bitcoin Cash Payments for WooCommerce plugin allows you to accept payments in bitcoin cash for physical and digital products at your WooCommerce-powered online store.
-Version: 4.16.1
+Version: 4.17
 Author: sanchaz
 Author URI: https://github.com/sanchaz/bitcoin-cash-payments-for-woocommerce
 License: GNU General Public License 2.0 (GPL) http://www.gnu.org/licenses/gpl.html

--- a/bwwc-admin.php
+++ b/bwwc-admin.php
@@ -59,6 +59,10 @@ $g_BWWC__config_defaults = array(
    'autocomplete_paid_orders'							=>  '1',
    'enable_soft_cron_job'                 =>  '1',    // Enable "soft" Wordpress-driven cron jobs.
 
+   // New BCH settings
+   'checkout_icon_select'                 =>  '',
+   ////////
+
    // ------- Copy of $this->settings of 'BWWC_Bitcoin' class.
    // DEPRECATED (only blockchain.info related settings still remain there.)
    'gateway_settings'                     =>  array('confirmations' => 6),

--- a/bwwc-cron.php
+++ b/bwwc-cron.php
@@ -16,11 +16,17 @@ if (@$_REQUEST['hardcron']=='1') {
 
 //===========================================================================
 // '$hardcron' == true if job is ran by Cpanel's cron job.
+// '$hardcron' is also affected by DISABLE_WP_CRON constant. If it is false
+// then the user has setup wp_cron via a real cron job and we can run as if
+// it is a $hardcron
 
 function BWWC_cron_job_worker($hardcron=false)
 {
     global $wpdb;
 
+    if (defined('DISABLE_WP_CRON') && constant('DISABLE_WP_CRON')) {
+        $hardcron = true;
+    }
 
     $bwwc_settings = BWWC__get_settings();
 

--- a/bwwc-include-all.php
+++ b/bwwc-include-all.php
@@ -8,7 +8,7 @@ https://github.com/sanchaz/bitcoin-cash-payments-for-woocommerce
 // Global definitions
 
 if (!defined('BWWC_PLUGIN_NAME')) {
-    define('BWWC_VERSION', '4.16.1');
+    define('BWWC_VERSION', '4.17');
 
     //-----------------------------------------------
     define('BWWC_EDITION', 'BCH');

--- a/bwwc-render-settings.php
+++ b/bwwc-render-settings.php
@@ -266,6 +266,8 @@ function BWWC__render_general_settings_page_html()
     } ?>
                 Cron job will take care of all regular bitcoin cash payment processing tasks, like checking if payments are made and automatically completing the orders.<br />
                 <b>Soft Cron</b>: - Wordpress-driven (runs on behalf of a random site visitor).
+                <br />If DISABLE_WP_CRON is true then this behaves like Hard Cron. However there is no need to run the script manually.
+                <br />DISABLE_WP_CRON is: <?php echo (defined('DISABLE_WP_CRON') && constant('DISABLE_WP_CRON') ? 'true' : 'false'); ?>
                 <br />
                 <b>Hard Cron</b>: - Cron job driven by the website hosting system/server (usually via CPanel). <br />
                 When enabling Hard Cron job - make this script to run every 5 minutes at your hosting panel cron job scheduler:<br />

--- a/readme.txt
+++ b/readme.txt
@@ -67,6 +67,10 @@ This is still in Beta, some bugs may be encountered please open an issue.
 
 == Changelog ==
 
+= 4.17 =
+* Hardcron behaviour now also happens if soft_cron is set and DISABLE_WP_CRON = true, ie the user is running it manually or through real cron
+* The template now features the amount after the address and a message.
+
 = 4.16 =
 * Added reuse_expired_addresses option in the menus for everyone
 


### PR DESCRIPTION
If DISABLE_WP_CRON is true then hard cron can be enabled as the user is
running the cron manually (I hope not) or through a real cron job.
Also improved the output messages for payment, to allow copy pasting
with the value and store name and order number.